### PR TITLE
Fix spatial frequency for non-square gratings

### DIFF
--- a/BonVision/Primitives/DrawGratings.bonsai
+++ b/BonVision/Primitives/DrawGratings.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.5.0"
+<WorkflowBuilder Version="2.6.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:bv="clr-namespace:BonVision;assembly=BonVision"
                  xmlns:gl="clr-namespace:Bonsai.Shaders;assembly=Bonsai.Shaders"
@@ -7,7 +7,6 @@
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns="https://bonsai-rx.org/2018/workflow">
-  <Description>Draws parameterized 2D sinewave gratings.</Description>
   <Workflow>
     <Nodes>
       <Expression xsi:type="WorkflowInput">
@@ -85,21 +84,7 @@
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>transform</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="ExternalizedMapping">
-              <Property Name="Angle" />
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="gl:CreateRotationZ">
-                <gl:Angle>0</gl:Angle>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="gl:UpdateUniform">
-                <gl:UniformName>rotation</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
+                <gl:ShaderName>Gratings_test</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -110,10 +95,7 @@
             <Edge From="2" To="4" Label="Source1" />
             <Edge From="3" To="4" Label="Source2" />
             <Edge From="4" To="5" Label="Source1" />
-            <Edge From="5" To="7" Label="Source1" />
-            <Edge From="6" To="7" Label="Source2" />
-            <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="9" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -149,6 +131,7 @@
               <Property Name="SpatialFrequency" Description="The spatial frequency of the gratings, in cycles per degree." Category="Stimulus Parameters" />
             </Expression>
             <Expression xsi:type="GroupWorkflow">
+              <Name>SetFrequency</Name>
               <Workflow>
                 <Nodes>
                   <Expression xsi:type="WorkflowInput">
@@ -159,13 +142,6 @@
                   </Expression>
                   <Expression xsi:type="PropertySource" TypeArguments="gl:Scale,sys:Single">
                     <MemberName>X</MemberName>
-                    <Value>1</Value>
-                  </Expression>
-                  <Expression xsi:type="ExternalizedMapping">
-                    <Property Name="Value" DisplayName="ExtentY" />
-                  </Expression>
-                  <Expression xsi:type="PropertySource" TypeArguments="gl:Scale,sys:Single">
-                    <MemberName>Y</MemberName>
                     <Value>1</Value>
                   </Expression>
                   <Expression xsi:type="ExternalizedMapping">
@@ -189,9 +165,45 @@
                   </Expression>
                   <Expression xsi:type="scr:ExpressionTransform">
                     <scr:Expression>single(
-Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
-(Item2 * Math.Sin(Item4) * Item2 * Math.Sin(Item4))) * Item3
+Item1 * Math.Cos(Item3) * Item2
 )</scr:Expression>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="gl:UpdateUniform">
+                      <gl:UniformName>frequency_x</gl:UniformName>
+                      <gl:ShaderName>Gratings_test</gl:ShaderName>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="ExternalizedMapping">
+                    <Property Name="Value" DisplayName="ExtentY" />
+                  </Expression>
+                  <Expression xsi:type="PropertySource" TypeArguments="gl:Scale,sys:Single">
+                    <MemberName>Y</MemberName>
+                    <Value>1</Value>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="FloatProperty">
+                      <Value>10</Value>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="FloatProperty">
+                      <Value>0</Value>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="scr:ExpressionTransform">
+                    <scr:Expression>single(
+Item1 * Math.Sin(Item3) * Item2
+)</scr:Expression>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="gl:UpdateUniform">
+                      <gl:UniformName>frequency_y</gl:UniformName>
+                      <gl:ShaderName>Gratings_test</gl:ShaderName>
+                    </Combinator>
                   </Expression>
                   <Expression xsi:type="WorkflowOutput" />
                 </Nodes>
@@ -199,25 +211,28 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
                   <Edge From="0" To="2" Label="Source1" />
                   <Edge From="0" To="4" Label="Source1" />
                   <Edge From="0" To="6" Label="Source1" />
-                  <Edge From="0" To="8" Label="Source1" />
                   <Edge From="1" To="2" Label="Source2" />
-                  <Edge From="2" To="9" Label="Source1" />
+                  <Edge From="2" To="7" Label="Source1" />
                   <Edge From="3" To="4" Label="Source2" />
-                  <Edge From="4" To="9" Label="Source2" />
+                  <Edge From="3" To="13" Label="Source2" />
+                  <Edge From="4" To="7" Label="Source3" />
                   <Edge From="5" To="6" Label="Source2" />
-                  <Edge From="6" To="9" Label="Source4" />
-                  <Edge From="7" To="8" Label="Source2" />
-                  <Edge From="8" To="9" Label="Source3" />
-                  <Edge From="9" To="10" Label="Source1" />
-                  <Edge From="10" To="11" Label="Source1" />
+                  <Edge From="5" To="12" Label="Source2" />
+                  <Edge From="6" To="7" Label="Source2" />
+                  <Edge From="7" To="8" Label="Source1" />
+                  <Edge From="8" To="9" Label="Source1" />
+                  <Edge From="9" To="11" Label="Source1" />
+                  <Edge From="9" To="12" Label="Source1" />
+                  <Edge From="9" To="13" Label="Source1" />
+                  <Edge From="10" To="11" Label="Source2" />
+                  <Edge From="11" To="14" Label="Source1" />
+                  <Edge From="12" To="14" Label="Source2" />
+                  <Edge From="13" To="14" Label="Source3" />
+                  <Edge From="14" To="15" Label="Source1" />
+                  <Edge From="15" To="16" Label="Source1" />
+                  <Edge From="16" To="17" Label="Source1" />
                 </Edges>
               </Workflow>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="gl:UpdateUniform">
-                <gl:UniformName>frequency</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
-              </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
               <Property Name="Value" DisplayName="Phase" Description="The optional phase offset of the grating stimulus, in degrees." Category="Stimulus Parameters" />
@@ -244,14 +259,12 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
               <Combinator xsi:type="rx:WithLatestFrom" />
             </Expression>
             <Expression xsi:type="MemberSelector">
-              <Selector>Item2,Item1</Selector>
+              <Selector>Item2</Selector>
             </Expression>
-            <Expression xsi:type="Divide" />
-            <Expression xsi:type="MemberSelector" />
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>phase</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
+                <gl:ShaderName>Gratings_test</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -263,20 +276,17 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
             <Edge From="3" To="5" Label="Source1" />
             <Edge From="4" To="5" Label="Source2" />
             <Edge From="5" To="6" Label="Source1" />
-            <Edge From="6" To="14" Label="Source1" />
+            <Edge From="6" To="13" Label="Source1" />
             <Edge From="7" To="8" Label="Source2" />
-            <Edge From="8" To="9" Label="Source1" />
-            <Edge From="9" To="15" Label="Source1" />
+            <Edge From="8" To="14" Label="Source1" />
+            <Edge From="9" To="10" Label="Source1" />
             <Edge From="10" To="11" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="12" To="13" Label="Source2" />
             <Edge From="13" To="14" Label="Source2" />
-            <Edge From="14" To="15" Label="Source2" />
+            <Edge From="14" To="15" Label="Source1" />
             <Edge From="15" To="16" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="18" Label="Source1" />
-            <Edge From="18" To="19" Label="Source1" />
-            <Edge From="19" To="20" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -305,7 +315,7 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>threshold</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
+                <gl:ShaderName>Gratings_test</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
@@ -319,7 +329,7 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>contrast</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
+                <gl:ShaderName>Gratings_test</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -354,7 +364,7 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>radius</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
+                <gl:ShaderName>Gratings_test</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
@@ -368,7 +378,7 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>aperture</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
+                <gl:ShaderName>Gratings_test</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
@@ -382,7 +392,7 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>opacity</gl:UniformName>
-                <gl:ShaderName>Gratings</gl:ShaderName>
+                <gl:ShaderName>Gratings_test</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -403,7 +413,7 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="gl:DrawMesh">
-          <gl:ShaderName>Gratings</gl:ShaderName>
+          <gl:ShaderName>Gratings_test</gl:ShaderName>
           <gl:MeshName>Quad</gl:MeshName>
         </Combinator>
       </Expression>
@@ -414,7 +424,6 @@ Math.Sqrt((Item1 * Math.Cos(Item4) * Item1 * Math.Cos(Item4)) +
       <Edge From="1" To="9" Label="Source2" />
       <Edge From="2" To="3" Label="Source1" />
       <Edge From="3" To="4" Label="Source1" />
-      <Edge From="4" To="9" Label="Source4" />
       <Edge From="4" To="10" Label="Source4" />
       <Edge From="5" To="10" Label="Source2" />
       <Edge From="6" To="11" Label="Source2" />

--- a/BonVision/Primitives/DrawGratings.bonsai
+++ b/BonVision/Primitives/DrawGratings.bonsai
@@ -84,7 +84,7 @@
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>transform</gl:UniformName>
-                <gl:ShaderName>Gratings_test</gl:ShaderName>
+                <gl:ShaderName>Gratings</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -171,7 +171,7 @@ Item1 * Math.Cos(Item3) * Item2
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="gl:UpdateUniform">
                       <gl:UniformName>frequency_x</gl:UniformName>
-                      <gl:ShaderName>Gratings_test</gl:ShaderName>
+                      <gl:ShaderName>Gratings</gl:ShaderName>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="ExternalizedMapping">
@@ -202,7 +202,7 @@ Item1 * Math.Sin(Item3) * Item2
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="gl:UpdateUniform">
                       <gl:UniformName>frequency_y</gl:UniformName>
-                      <gl:ShaderName>Gratings_test</gl:ShaderName>
+                      <gl:ShaderName>Gratings</gl:ShaderName>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="WorkflowOutput" />
@@ -264,7 +264,7 @@ Item1 * Math.Sin(Item3) * Item2
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>phase</gl:UniformName>
-                <gl:ShaderName>Gratings_test</gl:ShaderName>
+                <gl:ShaderName>Gratings</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -315,7 +315,7 @@ Item1 * Math.Sin(Item3) * Item2
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>threshold</gl:UniformName>
-                <gl:ShaderName>Gratings_test</gl:ShaderName>
+                <gl:ShaderName>Gratings</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
@@ -329,7 +329,7 @@ Item1 * Math.Sin(Item3) * Item2
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>contrast</gl:UniformName>
-                <gl:ShaderName>Gratings_test</gl:ShaderName>
+                <gl:ShaderName>Gratings</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -364,7 +364,7 @@ Item1 * Math.Sin(Item3) * Item2
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>radius</gl:UniformName>
-                <gl:ShaderName>Gratings_test</gl:ShaderName>
+                <gl:ShaderName>Gratings</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
@@ -378,7 +378,7 @@ Item1 * Math.Sin(Item3) * Item2
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>aperture</gl:UniformName>
-                <gl:ShaderName>Gratings_test</gl:ShaderName>
+                <gl:ShaderName>Gratings</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
@@ -392,7 +392,7 @@ Item1 * Math.Sin(Item3) * Item2
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="gl:UpdateUniform">
                 <gl:UniformName>opacity</gl:UniformName>
-                <gl:ShaderName>Gratings_test</gl:ShaderName>
+                <gl:ShaderName>Gratings</gl:ShaderName>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -413,7 +413,7 @@ Item1 * Math.Sin(Item3) * Item2
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="gl:DrawMesh">
-          <gl:ShaderName>Gratings_test</gl:ShaderName>
+          <gl:ShaderName>Gratings</gl:ShaderName>
           <gl:MeshName>Quad</gl:MeshName>
         </Combinator>
       </Expression>

--- a/BonVision/Shaders/Gratings.frag
+++ b/BonVision/Shaders/Gratings.frag
@@ -3,7 +3,8 @@ const float pi = 3.1415926535897932384626433832795;
 const float sqrtTwoPi = sqrt(2 * pi);
 uniform float radius = 1;
 uniform float aperture = 0;
-uniform float frequency = 1;
+uniform float frequency_x = 1;
+uniform float frequency_y = 0;
 uniform float contrast = 1;
 uniform float phase = 0;
 uniform float opacity = 1;
@@ -13,7 +14,7 @@ out vec4 fragColor;
 
 void main()
 {
-  float value = (texCoord.x + phase) * frequency;
+  float value = texCoord.x * frequency_x + texCoord.y * frequency_y + phase;
   if (threshold < 0) value = sin(value * 2 * pi); // sinewave
   else value = mod(value, 1) > threshold ? -1 : 1; // square modulation
 

--- a/BonVision/Shaders/Gratings.vert
+++ b/BonVision/Shaders/Gratings.vert
@@ -1,13 +1,11 @@
 #version 400
 uniform mat4 transform = mat4(1);
-uniform mat4 rotation = mat4(1);
 layout(location = 0) in vec2 vp;
 layout(location = 1) in vec2 vt;
 out vec2 texCoord;
 
 void main()
 {
-  mat2 texRotation = mat2(rotation[0][0], rotation[1][0], rotation[0][1], rotation[1][1]);
   gl_Position = transform * vec4(vp, 0.0, 1.0);
-  texCoord = texRotation * (vt - 0.5) + 0.5;
+  texCoord = vt;
 }


### PR DESCRIPTION
Proposed fix for issue #7.

`Grating.vert` now simply returns `vt` as `texCoord`. `Grating.frag` has separate `frequency_x` and `frequency_y` uniforms and grating orientation is set by adjusting them in the workflow. 

The alternative would be to adjust the way SF and Angle are calculated in the workflow before being passed to the shader, but I think separating `frequency_x` and `frequency_y` is more readable and easier to maintain.